### PR TITLE
fix: A/B test scoring integrity, active_version_id scope, createPrompt transaction

### DIFF
--- a/src/controllers/ab-test.controller.ts
+++ b/src/controllers/ab-test.controller.ts
@@ -23,8 +23,8 @@ export class ABTestController {
   }
 
   async listTests(req: Request, res: Response): Promise<void> {
-    const page = Number(req.query.page) || 1;
-    const limit = Number(req.query.limit) || 50;
+    const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string, 10) || 50));
     const workspaceId = req.workspaceId || 'default';
     const result = await this.service.listTests(page, limit, workspaceId);
     res.status(200).json(result);
@@ -45,40 +45,47 @@ export class ABTestController {
 
     const id = parseIdParam(req.params.id);
     const workspaceId = req.workspaceId || 'default';
+    const test = await this.service.getTest(id, workspaceId);
 
     let scoresA: number[] | undefined = value.scoresA;
     let scoresB: number[] | undefined = value.scoresB;
 
-    if (!scoresA || !scoresB) {
-      const test = await this.service.getTest(id, workspaceId);
+    // Bug #7: When evaluation_id is set, always use evaluation-based scoring.
+    // Reject manual scores to prevent a client from overriding results.
+    if (test.evaluation_id) {
+      if (scoresA || scoresB) {
+        throw AppError.badRequest(
+          'This A/B test uses evaluation-based scoring. Remove scoresA/scoresB from the request body; scores are computed from the linked evaluation.',
+        );
+      }
+      scoresA = await this.service.getEvaluationScores(test.evaluation_id, test.prompt_name, test.version_a, workspaceId);
+      scoresB = await this.service.getEvaluationScores(test.evaluation_id, test.prompt_name, test.version_b, workspaceId);
+    } else if (!scoresA || !scoresB) {
+      const metric = test.metric || 'latency';
 
-      if (!test.evaluation_id) {
-        const metric = test.metric || 'latency';
+      const logsA = await this.logService.getLogsForPromptVersion(test.prompt_name, test.version_a, workspaceId);
+      const logsB = await this.logService.getLogsForPromptVersion(test.prompt_name, test.version_b, workspaceId);
 
-        const logsA = await this.logService.getLogsForPromptVersion(test.prompt_name, test.version_a, workspaceId);
-        const logsB = await this.logService.getLogsForPromptVersion(test.prompt_name, test.version_b, workspaceId);
-
-        const extractScore = (log: {
-          latency_ms?: number | null;
-          cost_usd?: number | null;
-          metadata?: Record<string, unknown>;
-        }): number => {
-          if (metric === 'latency') return log.latency_ms ?? 0;
-          if (metric === 'cost') return log.cost_usd ?? 0;
-          if (metric === 'win_rate') {
-            const meta = log.metadata ?? {};
-            const rating = meta.rating ?? meta.score ?? meta.win;
-            return typeof rating === 'number' ? rating : 0;
-          }
-          return log.latency_ms ?? 0;
-        };
-
-        scoresA = logsA.map(extractScore).filter((s) => s > 0);
-        scoresB = logsB.map(extractScore).filter((s) => s > 0);
-
-        if (scoresA.length === 0 || scoresB.length === 0) {
-          throw AppError.badRequest('Insufficient logs to auto-compute scores for this A/B test');
+      const extractScore = (log: {
+        latency_ms?: number | null;
+        cost_usd?: number | null;
+        metadata?: Record<string, unknown>;
+      }): number => {
+        if (metric === 'latency') return log.latency_ms ?? 0;
+        if (metric === 'cost') return log.cost_usd ?? 0;
+        if (metric === 'win_rate') {
+          const meta = log.metadata ?? {};
+          const rating = meta.rating ?? meta.score ?? meta.win;
+          return typeof rating === 'number' ? rating : 0;
         }
+        return log.latency_ms ?? 0;
+      };
+
+      scoresA = logsA.map(extractScore).filter((s) => s > 0);
+      scoresB = logsB.map(extractScore).filter((s) => s > 0);
+
+      if (scoresA.length === 0 || scoresB.length === 0) {
+        throw AppError.badRequest('Insufficient logs to auto-compute scores for this A/B test');
       }
     }
 

--- a/src/services/ab-test.service.ts
+++ b/src/services/ab-test.service.ts
@@ -56,6 +56,15 @@ export class ABTestService {
     private evaluationService = new EvaluationService(),
   ) {}
 
+  async getEvaluationScores(
+    evaluationId: number,
+    promptName: string,
+    versionTag: string,
+    workspaceId: string,
+  ): Promise<number[]> {
+    return this.evaluationService.getResultsForVersion(evaluationId, promptName, versionTag, workspaceId);
+  }
+
   async createTest(input: CreateABTestInput, workspaceId: string = 'default'): Promise<ABTest> {
     const db = getDb();
     const insertResult = await db
@@ -245,8 +254,8 @@ export class ABTestService {
 
         if (promptRow) {
           await db
-            .prepare('UPDATE prompts SET active_version_id = ? WHERE name = ? AND workspace_id = ?')
-            .run(promptRow.id, test.prompt_name, workspaceId);
+            .prepare('UPDATE prompts SET active_version_id = ? WHERE id = ? AND workspace_id = ?')
+            .run(promptRow.id, promptRow.id, workspaceId);
         }
 
         await db

--- a/src/services/prompt.service.ts
+++ b/src/services/prompt.service.ts
@@ -123,26 +123,32 @@ export class PromptService {
     const db = getDb();
     const now = Math.floor(Date.now() / 1000);
 
-    // Step 1: insert pending row (or reset existing to pending)
-    await db
-      .prepare(
-        `INSERT INTO prompts (name, version_tag, workspace_id, status, driver, created_at)
-         VALUES (?, ?, ?, ?, ?, ?)
-         ON CONFLICT(name, version_tag) DO UPDATE SET
-           workspace_id = excluded.workspace_id,
-           status = 'pending',
-           driver = excluded.driver,
-           created_at = excluded.created_at`,
-      )
-      .run(prompt.name, prompt.version, workspaceId, 'pending', config.driver, now);
+    // Wrap the three-step write in a transaction so that if the driver
+    // write fails, the pending row is rolled back instead of orphaned.
+    const result = await db.transaction(async () => {
+      // Step 1: insert pending row (or reset existing to pending)
+      await db
+        .prepare(
+          `INSERT INTO prompts (name, version_tag, workspace_id, status, driver, created_at)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(name, version_tag) DO UPDATE SET
+             workspace_id = excluded.workspace_id,
+             status = 'pending',
+             driver = excluded.driver,
+             created_at = excluded.created_at`,
+        )
+        .run(prompt.name, prompt.version, workspaceId, 'pending', config.driver, now);
 
-    // Step 2: driver writes content and updates its own fields via ON CONFLICT
-    const result = await this.driver.createPrompt(prompt);
+      // Step 2: driver writes content and updates its own fields via ON CONFLICT
+      const driverResult = await this.driver.createPrompt(prompt);
 
-    // Step 3: activate
-    await db
-      .prepare("UPDATE prompts SET status = 'active' WHERE name = ? AND version_tag = ?")
-      .run(prompt.name, prompt.version);
+      // Step 3: activate
+      await db
+        .prepare("UPDATE prompts SET status = 'active' WHERE name = ? AND version_tag = ?")
+        .run(prompt.name, prompt.version);
+
+      return driverResult;
+    });
 
     await invalidatePrompt(workspaceId, prompt.name);
     return result;


### PR DESCRIPTION
Fixes #8 #9 #10

Data integrity fixes:

- **#8** active_version_id UPDATE scoped to single row by id (was updating all rows for prompt name)
- **#9** Reject manual scoresA/scoresB when A/B test has evaluation_id — always use evaluation scoring
- **#10** Wrap createPrompt 3-step write in db.transaction() so driver failures roll back pending rows