### PR TITLE
fix: playground assistant messages, sql-builder validation, redundant RETURNING id, active_version_id, NULL workspace_id, compliance cursor (#109-#114)

### DIFF
--- a/src/middlewares/promptmetrics-auth.middleware.ts
+++ b/src/middlewares/promptmetrics-auth.middleware.ts
@@ -31,7 +31,8 @@ export async function authenticateApiKey(req: Request, _res: Response, next: Nex
   }
 
   const workspaceId = req.workspaceId || 'default';
-  if (row.workspace_id !== workspaceId && row.workspace_id !== '*') {
+  const keyWorkspace = row.workspace_id || 'default';
+  if (keyWorkspace !== workspaceId && keyWorkspace !== '*') {
     throw AppError.unauthorized('API key does not belong to this workspace');
   }
 

--- a/src/services/compliance.service.ts
+++ b/src/services/compliance.service.ts
@@ -36,15 +36,35 @@ export class ComplianceService {
   ): Promise<CursorPaginatedComplianceResponse> {
     const db = getDb();
     const effectiveLimit = Math.min(200, Math.max(1, limit || 50));
-    const cursorTimestamp = cursor ? parseInt(Buffer.from(cursor, 'base64').toString('utf8'), 10) : undefined;
 
-    const sql = cursorTimestamp
-      ? 'SELECT * FROM compliance_scores WHERE workspace_id = ? AND created_at < ? ORDER BY created_at DESC LIMIT ?'
-      : 'SELECT * FROM compliance_scores WHERE workspace_id = ? ORDER BY created_at DESC LIMIT ?';
+    // Cursor format: base64("created_at:id")
+    let cursorCreatedAt: number | undefined;
+    let cursorId: number | undefined;
+    if (cursor) {
+      const decoded = Buffer.from(cursor, 'base64').toString('utf8');
+      const parts = decoded.split(':');
+      cursorCreatedAt = parseInt(parts[0], 10);
+      cursorId = parseInt(parts[1], 10);
+    }
 
-    const params = cursorTimestamp
-      ? [workspaceId, cursorTimestamp, effectiveLimit + 1]
-      : [workspaceId, effectiveLimit + 1];
+    let sql: string;
+    let params: unknown[];
+    const dialect = db.dialect;
+
+    if (cursorCreatedAt !== undefined && cursorId !== undefined) {
+      if (dialect === 'postgres') {
+        // PostgreSQL supports row-value comparisons: (created_at, id) < (?, ?)
+        sql = 'SELECT * FROM compliance_scores WHERE workspace_id = ? AND (created_at, id) < (?, ?) ORDER BY created_at DESC, id DESC LIMIT ?';
+        params = [workspaceId, cursorCreatedAt, cursorId, effectiveLimit + 1];
+      } else {
+        // SQLite doesn't support row-value comparisons, so use equivalent OR logic
+        sql = 'SELECT * FROM compliance_scores WHERE workspace_id = ? AND (created_at < ? OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?';
+        params = [workspaceId, cursorCreatedAt, cursorCreatedAt, cursorId, effectiveLimit + 1];
+      }
+    } else {
+      sql = 'SELECT * FROM compliance_scores WHERE workspace_id = ? ORDER BY created_at DESC, id DESC LIMIT ?';
+      params = [workspaceId, effectiveLimit + 1];
+    }
 
     const items = (await db.prepare(sql).all(...params)) as Array<{
       id: number;
@@ -59,9 +79,10 @@ export class ComplianceService {
 
     const hasMore = items.length > effectiveLimit;
     const trimmed = hasMore ? items.slice(0, effectiveLimit) : items;
+    const last = trimmed[trimmed.length - 1];
     const nextCursor =
-      hasMore && trimmed.length > 0
-        ? Buffer.from(String(trimmed[trimmed.length - 1].created_at), 'utf8').toString('base64')
+      hasMore && last
+        ? Buffer.from(`${last.created_at}:${last.id}`, 'utf8').toString('base64')
         : null;
 
     return {

--- a/src/services/evaluation.service.ts
+++ b/src/services/evaluation.service.ts
@@ -42,8 +42,7 @@ export class EvaluationService {
     const result = await db
       .prepare(
         `INSERT INTO evaluations (name, description, prompt_name, version_tag, criteria_json, workspace_id)
-       VALUES (?, ?, ?, ?, ?, ?)
-       RETURNING id`,
+       VALUES (?, ?, ?, ?, ?, ?)`,
       )
       .run(
         input.name,
@@ -189,8 +188,7 @@ export class EvaluationService {
     const result = await db
       .prepare(
         `INSERT INTO evaluation_results (evaluation_id, run_id, score, metadata_json, workspace_id)
-       VALUES (?, ?, ?, ?, ?)
-       RETURNING id`,
+       VALUES (?, ?, ?, ?, ?)`,
       )
       .run(
         evaluationId,

--- a/src/services/playground.service.ts
+++ b/src/services/playground.service.ts
@@ -55,10 +55,12 @@ export class PlaygroundProxyService {
     if (!variables || Object.keys(variables).length === 0) {
       return messages;
     }
-    return messages.map((m) => ({
-      ...m,
-      content: renderTemplate(m.content, variables, { strict: true }),
-    }));
+    // Skip assistant-role messages — they are example outputs, not templates.
+    // This matches PromptService.getPrompt() which also skips assistant messages.
+    return messages.map((m) => {
+      if (m.role === 'assistant') return m;
+      return { ...m, content: renderTemplate(m.content, variables, { strict: true }) };
+    });
   }
 
   private async logRun(

--- a/src/services/prompt.service.ts
+++ b/src/services/prompt.service.ts
@@ -62,7 +62,19 @@ export class PromptService {
       throw AppError.notFound('Prompt');
     }
 
-    const key = cacheKey(workspaceId, name, version);
+    // If no version is specified and an active_version_id is set, use that version
+    // instead of falling through to the driver's "latest" logic.
+    let effectiveVersion = version;
+    if (!version) {
+      const activeVersion = (await db
+        .prepare("SELECT version_tag FROM prompts WHERE id = (SELECT active_version_id FROM prompts WHERE name = ? AND workspace_id = ? AND status = 'active' LIMIT 1)")
+        .get(name, workspaceId)) as { version_tag: string } | undefined;
+      if (activeVersion) {
+        effectiveVersion = activeVersion.version_tag;
+      }
+    }
+
+    const key = cacheKey(workspaceId, name, effectiveVersion);
     const cached = await getCachedPrompt(key);
 
     let rawContent: PromptFile;
@@ -72,7 +84,7 @@ export class PromptService {
       rawContent = cached.content;
       promptVersion = cached.version;
     } else {
-      const result = await this.driver.getPrompt(name, version);
+      const result = await this.driver.getPrompt(name, effectiveVersion);
       if (!result) {
         throw AppError.notFound('Prompt');
       }

--- a/src/utils/sql-builder.ts
+++ b/src/utils/sql-builder.ts
@@ -1,3 +1,18 @@
+const ALLOWED_COLUMNS = new Set([
+  'status',
+  'output_json',
+  'metadata_json',
+  'updated_at',
+  'run_id',
+  'workspace_id',
+]);
+
+function validateColumn(column: string): void {
+  if (!ALLOWED_COLUMNS.has(column)) {
+    throw new Error('Invalid column name: ' + column);
+  }
+}
+
 export function buildPartialUpdate(
   table: string,
   fields: Array<{ column: string; value: unknown }>,
@@ -5,6 +20,12 @@ export function buildPartialUpdate(
 ): { sql: string; params: unknown[] } {
   if (fields.length === 0) {
     throw new Error('No fields to update');
+  }
+  for (const f of fields) {
+    validateColumn(f.column);
+  }
+  for (const w of whereColumns) {
+    validateColumn(w.column);
   }
   const setClauses = fields.map((f) => `${f.column} = ?`);
   const whereClauses = whereColumns.map((w) => `${w.column} = ?`);


### PR DESCRIPTION
Fixes #109 #110 #111 #112 #113 #114

#109: Playground renderMessages now skips assistant-role messages, matching PromptService.getPrompt behavior.

#110: Added column name whitelist to buildPartialUpdate. Only status, output_json, metadata_json, updated_at, run_id, and workspace_id are allowed. Throws on unrecognized columns.

#111: Removed explicit RETURNING id from EvaluationService INSERTs. PostgresAdapter auto-appends it, SQLite uses lastInsertRowid.

#112: PromptService.getPrompt now checks active_version_id before falling through to the driver, so promoted A/B test winners are actually served.

#113: Auth middleware treats NULL workspace_id as equivalent to default, preventing pre-migration API keys from being rejected.

#114: Compliance cursor pagination now uses composite created_at:id cursor. Postgres uses row-value comparison WHERE (created_at, id) < (?, ?). SQLite uses OR-equivalent WHERE created_at < ? OR (created_at = ? AND id < ?). Both include id DESC tiebreaker in ORDER BY.