### PR TITLE
fix: document Mustache escape, add models cache refresh endpoint, document driver search trade-off (#84 #95 #97)

### DIFF
--- a/src/controllers/playground.controller.ts
+++ b/src/controllers/playground.controller.ts
@@ -130,4 +130,14 @@ export class PlaygroundController {
     const result = await this.service.listModels(workspaceId, page, limit);
     res.json(result);
   }
+
+  async refreshModels(req: Request, res: Response): Promise<void> {
+    const page = Math.max(1, parseInt(req.query.page as string, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string, 10) || 50));
+    const workspaceId = req.workspaceId || 'default';
+
+    this.service.clearModelsCache();
+    const result = await this.service.listModels(workspaceId, page, limit);
+    res.json(result);
+  }
 }

--- a/src/routes/playground.route.ts
+++ b/src/routes/playground.route.ts
@@ -18,6 +18,13 @@ export function createPlaygroundRoutes(): Router {
   router.get('/v1/playground/models', (req, res) => controller.listModels(req, res));
 
   router.post(
+    '/v1/playground/models/refresh',
+    requireScope('admin'),
+    auditLog('playground_models_refresh'),
+    (req, res) => controller.refreshModels(req, res),
+  );
+
+  router.post(
     '/v1/playground/chat',
     validateBody(playgroundChatSchema),
     requireScope('write'),

--- a/src/services/prompt.service.ts
+++ b/src/services/prompt.service.ts
@@ -19,11 +19,17 @@ export class PromptService {
     const { offset } = parsePagination({ page: String(page), limit: String(limit) });
 
     if (query) {
-      // NOTE: driver.search() is not workspace-scoped — it may return prompt
-      // names from other workspaces. The DB query below filters by workspace_id,
-      // so only names that exist in the requesting workspace are returned.
-      // Prompt names themselves are not sensitive content; the content is only
-      // returned after the workspace check in getPrompt().
+      // DESIGN NOTE (wontfix): driver.search() is not workspace-scoped — it
+      // searches across all workspaces and may return prompt names belonging to
+      // other tenants. The subsequent DB query filters by workspace_id so that
+      // only names present in the requesting workspace are returned to the
+      // caller. Prompt names themselves are not sensitive content (the full
+      // content is gated by getPrompt()'s workspace check), but the fact that
+      // a name exists in another workspace is visible to the driver layer.
+      // Properly scoping search would require adding a workspaceId parameter
+      // to the PromptDriver.search() interface and all three driver
+      // implementations (filesystem, GitHub, S3), which is a larger change
+      // than the current risk justifies. Accepted as a known trade-off.
       const driverItems = await this.driver.search(query);
       if (driverItems.length === 0) {
         return buildPaginatedResponse([], 0, page, limit);
@@ -94,9 +100,14 @@ export class PromptService {
       }
 
       if (variables && Object.keys(variables).length > 0) {
-        // Disable Mustache's HTML escaping — prompt content is sent to LLMs,
-        // not rendered in HTML. The UI layer must apply its own escaping when
-        // displaying prompt content.
+        // Mustache's default escape function HTML-escapes values (e.g. "<" →
+        // "&lt;"). That is wrong for prompt content, which is sent to LLMs —
+        // not rendered in HTML — so we intentionally disable it here. There is
+        // currently no way to opt into HTML escaping; if prompts are ever
+        // displayed in a web UI, the UI layer must apply its own escaping at
+        // render time.
+        // See also: mustache-renderer.service.ts renderTemplate(), which
+        // applies the same policy for playground prompts.
         const renderedMessages = content.messages.map((msg) => {
           if (msg.role === 'assistant') return msg;
           const rendered = mustache.render(msg.content, variables, undefined, { escape: (text) => text });


### PR DESCRIPTION
Fixes #84 #95. Closes #97 as wontfix.

#84: Added thorough documentation comment above the Mustache escape override in PromptService, explaining that prompt content is sent to LLMs (not rendered in HTML), HTML escaping is intentionally disabled, and the UI layer must apply its own escaping. Cross-references mustache-renderer.service.ts.

#95: Added POST /v1/playground/models/refresh endpoint that calls clearModelsCache() then fetches a fresh list. Protected with requireScope('admin') and audit logging. This lets operators invalidate the models cache without waiting for the 60s TTL.

#97: Won't fix — driver.search() crossing workspace boundaries is an acknowledged design trade-off. The DB query already filters results to the requesting workspace, and prompt names are not sensitive (content is gated by getPrompt). Properly scoping search would require extending the PromptDriver interface across all three implementations. Added a DESIGN NOTE (wontfix) comment documenting this decision.