### PR TITLE
fix(#124,#125,#126,#129,#141): data integrity fixes

### DIFF
--- a/src/controllers/dataset.controller.ts
+++ b/src/controllers/dataset.controller.ts
@@ -1,4 +1,5 @@
 import { parseIdParam } from '@utils/validation';
+import { parsePagination } from '@utils/pagination';
 import { Request, Response } from 'express';
 import { AppError } from '@errors/app.error';
 import { DatasetService } from '@services/dataset.service';
@@ -19,8 +20,7 @@ export class DatasetController {
   }
 
   async listDatasets(req: Request, res: Response): Promise<void> {
-    const page = Number(req.query.page) || 1;
-    const limit = Number(req.query.limit) || 50;
+    const { page, limit } = parsePagination(req.query);
     const workspaceId = req.workspaceId || 'default';
     const result = await this.service.listDatasets(page, limit, workspaceId);
     res.status(200).json(result);

--- a/src/drivers/promptmetrics-github-driver.ts
+++ b/src/drivers/promptmetrics-github-driver.ts
@@ -273,13 +273,14 @@ export class GithubDriver implements PromptDriver {
     name: string,
     page: number = 1,
     limit: number = 50,
+    workspaceId: string = 'default',
   ): Promise<{ items: PromptVersion[]; total: number }> {
     const db = getDb();
     const rows = (await db
-      .prepare('SELECT * FROM prompts WHERE name = ? ORDER BY created_at DESC LIMIT ? OFFSET ?')
-      .all(name, limit, (page - 1) * limit)) as PromptVersion[];
+      .prepare('SELECT * FROM prompts WHERE name = ? AND workspace_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?')
+      .all(name, workspaceId, limit, (page - 1) * limit)) as PromptVersion[];
 
-    const total = parseCountRow(await db.prepare('SELECT COUNT(*) as count FROM prompts WHERE name = ?').get(name));
+    const total = parseCountRow(await db.prepare('SELECT COUNT(*) as count FROM prompts WHERE name = ? AND workspace_id = ?').get(name, workspaceId));
 
     return { items: rows, total };
   }

--- a/src/services/compliance.service.ts
+++ b/src/services/compliance.service.ts
@@ -51,6 +51,9 @@ export class ComplianceService {
       const parts = decoded.split(':');
       cursorCreatedAt = parseInt(parts[0], 10);
       cursorId = parseInt(parts[1], 10);
+      if (!Number.isFinite(cursorCreatedAt) || !Number.isFinite(cursorId)) {
+        throw AppError.badRequest('Invalid cursor parameter');
+      }
     }
 
     let sql: string;

--- a/src/services/evaluation.service.ts
+++ b/src/services/evaluation.service.ts
@@ -161,10 +161,10 @@ export class EvaluationService {
          WHERE er.evaluation_id = ?
            AND e.prompt_name = ?
            AND er.workspace_id = ?
-           AND e.version_tag = ?
+           AND (e.version_tag = ? OR (e.version_tag IS NULL AND ? IS NULL))
            AND er.score IS NOT NULL`,
       )
-      .all(evalId, promptName, workspaceId, versionTag)) as Array<{ score: number }>;
+      .all(evalId, promptName, workspaceId, versionTag, versionTag)) as Array<{ score: number }>;
 
     return rows.map((r) => r.score);
   }

--- a/src/services/prompt.service.ts
+++ b/src/services/prompt.service.ts
@@ -80,7 +80,7 @@ export class PromptService {
     if (!version) {
       const activeVersion = (await db
         .prepare(
-          "SELECT version_tag FROM prompts WHERE id = (SELECT active_version_id FROM prompts WHERE name = ? AND workspace_id = ? AND status = 'active' LIMIT 1)",
+          "SELECT version_tag FROM prompts WHERE id = (SELECT active_version_id FROM prompts WHERE name = ? AND workspace_id = ? AND status = 'active' AND active_version_id IS NOT NULL LIMIT 1)",
         )
         .get(name, workspaceId)) as { version_tag: string } | undefined;
       if (activeVersion) {


### PR DESCRIPTION
## Fixes

- **#124**: Fix `getPrompt` active_version subquery to filter `NULL` rows. Added `AND active_version_id IS NOT NULL` so the subquery doesn't match rows where `active_version_id` is NULL.
- **#125**: Add `workspace_id` filter to `GithubDriver.listVersions()`. The SQL queries were missing `AND workspace_id = ?`, leaking prompt versions across workspace boundaries.
- **#126**: Validate compliance cursor pagination values. `parseInt` on malformed cursors returns `NaN`, which caused empty results on SQLite and 500 errors on Postgres. Now throws a 400 error for invalid cursors.
- **#129**: Use `parsePagination()` in `DatasetController.listDatasets` instead of raw `Number()` conversion. This clamps limit to 1-100 and prevents unbounded queries.
- **#141**: Fix `getResultsForVersion` for NULL `version_tag` evaluations. Changed `e.version_tag = ?` to `(e.version_tag = ? OR (e.version_tag IS NULL AND ? IS NULL))` so A/B tests linked to versionless evaluations return results correctly.