### PR TITLE
fix(#121,#131,#136): provider adapter fixes

### DIFF
--- a/src/services/providers/anthropic.adapter.ts
+++ b/src/services/providers/anthropic.adapter.ts
@@ -27,7 +27,7 @@ function mapAnthropicError(err: unknown): ProviderError {
       return ProviderError.rateLimit('anthropic');
     }
     if (status === 529) {
-      return ProviderError.unknown('anthropic', 'Anthropic API is overloaded');
+      return ProviderError.rateLimit('anthropic');
     }
     if (status === 400) {
       return ProviderError.invalidRequest('anthropic', message);
@@ -78,15 +78,16 @@ export class AnthropicAdapter implements LLMProviderAdapter {
     const startTime = Date.now();
 
     try {
+      const systemMessages = request.messages.filter((m) => m.role === 'system').map((m) => m.content).join('\n');
+      const apiMessages = request.messages
+        .filter((m) => m.role !== 'system')
+        .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }));
+
       const response = await this.getClient().messages.create({
         model: request.model,
         max_tokens: request.maxTokens ?? 4096,
-        messages: request.messages.map((m) => {
-          if (m.role === 'system') {
-            return { role: 'user' as const, content: `[System]\n${m.content}` };
-          }
-          return { role: m.role, content: m.content };
-        }),
+        system: systemMessages || undefined,
+        messages: apiMessages,
         temperature: request.temperature,
         top_p: request.topP,
       });
@@ -116,16 +117,17 @@ export class AnthropicAdapter implements LLMProviderAdapter {
     const startTime = Date.now();
 
     try {
+      const systemMessages = request.messages.filter((m) => m.role === 'system').map((m) => m.content).join('\n');
+      const apiMessages = request.messages
+        .filter((m) => m.role !== 'system')
+        .map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content }));
+
       const stream = await this.getClient().messages.create(
         {
           model: request.model,
           max_tokens: request.maxTokens ?? 4096,
-          messages: request.messages.map((m) => {
-            if (m.role === 'system') {
-              return { role: 'user' as const, content: `[System]\n${m.content}` };
-            }
-            return { role: m.role, content: m.content };
-          }),
+          system: systemMessages || undefined,
+          messages: apiMessages,
           temperature: request.temperature,
           top_p: request.topP,
           stream: true,

--- a/src/services/providers/ollama.adapter.ts
+++ b/src/services/providers/ollama.adapter.ts
@@ -192,6 +192,20 @@ export class OllamaAdapter implements LLMProviderAdapter {
         reader.releaseLock();
       }
 
+      // Process any remaining buffer content (e.g., final JSON without trailing newline)
+      if (buffer.trim()) {
+        const parsed = safeJsonParse<OllamaStreamChunk | null>(buffer.trim(), null);
+        if (parsed) {
+          if (parsed.message?.content) {
+            tokensOut += 1;
+            yield { type: 'token', content: parsed.message.content };
+          }
+          if (parsed.done) {
+            finishReason = parsed.done_reason || 'stop';
+          }
+        }
+      }
+
       const tokensIn = this.estimateTokensIn(request);
       const latencyMs = Date.now() - startTime;
 


### PR DESCRIPTION
## Fixes

- **#121**: Use the Anthropic API's dedicated `system` parameter instead of converting system-role messages to user-role with a `[System]` prefix. The previous approach caused consecutive-user-message errors and degraded instruction-following. System messages are now extracted and passed via the top-level `system` field, and the remaining messages are cast to `'user' | 'assistant'` to satisfy the Anthropic SDK types.
- **#131**: Map Anthropic HTTP 529 (Overloaded) to `ProviderError.rateLimit()` instead of `ProviderError.unknown()`. This makes 529 errors retryable by callers that check for rate-limit errors.
- **#136**: Process the remaining buffer content in Ollama streaming after the while loop exits. Previously, if the server's final JSON object didn't end with a newline, it was left in the buffer and silently discarded. This could cause the final token or `done_reason` to be lost.