### PR TITLE
fix(#127,#128,#134): schema cache, Redis SCAN, Postgres transaction retry

### DIFF
--- a/src/models/postgres.adapter.ts
+++ b/src/models/postgres.adapter.ts
@@ -166,26 +166,16 @@ class TransactionPreparedStatement implements PreparedStatement {
     const isInsert = /^\s*INSERT\s+INTO/i.test(sql);
     const hasReturning = /\bRETURNING\b/i.test(sql);
 
+    // Inside a transaction, retrying after RETURNING id failure is impossible
+    // because PostgreSQL aborts the transaction on 42703. Only attempt
+    // RETURNING id for tables known to have an id column.
     if (isInsert && !hasReturning && tableHasId(sql)) {
       const returningSql = `${sql} RETURNING id`;
-      try {
-        const result = await this.client.query(returningSql, params);
-        return {
-          lastInsertRowid: result.rows[0]?.id ?? 0,
-          changes: result.rowCount ?? 0,
-        };
-      } catch (err: any) {
-        // If RETURNING id fails because the table has no id column,
-        // retry without RETURNING (e.g., migrations table).
-        if (err.code === '42703' || err.message?.toLowerCase().includes('column "id" does not exist')) {
-          const result = await this.client.query(sql, params);
-          return {
-            lastInsertRowid: 0,
-            changes: result.rowCount ?? 0,
-          };
-        }
-        throw err;
-      }
+      const result = await this.client.query(returningSql, params);
+      return {
+        lastInsertRowid: result.rows[0]?.id ?? 0,
+        changes: result.rowCount ?? 0,
+      };
     }
 
     const result = await this.client.query(sql, params);

--- a/src/services/cache.service.ts
+++ b/src/services/cache.service.ts
@@ -51,7 +51,14 @@ export async function invalidatePrompt(workspaceId: string, name: string): Promi
   if (isRedisEnabled()) {
     const redis = getRedisClient();
     if (redis) {
-      const keys = await redis.keys(`prompt:${workspaceId}:${name}:*`);
+      const pattern = `prompt:${workspaceId}:${name}:*`;
+      const keys: string[] = [];
+      let cursor = '0';
+      do {
+        const result = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
+        cursor = result[0];
+        keys.push(...result[1]);
+      } while (cursor !== '0');
       if (keys.length > 0) {
         await redis.del(...keys);
       }
@@ -69,7 +76,13 @@ export async function clearCache(): Promise<void> {
   if (isRedisEnabled()) {
     const redis = getRedisClient();
     if (redis) {
-      const keys = await redis.keys('prompt:*');
+      const keys: string[] = [];
+      let cursor = '0';
+      do {
+        const result = await redis.scan(cursor, 'MATCH', 'prompt:*', 'COUNT', 100);
+        cursor = result[0];
+        keys.push(...result[1]);
+      } while (cursor !== '0');
       if (keys.length > 0) {
         await redis.del(...keys);
       }

--- a/src/services/evaluation-rule.engine.ts
+++ b/src/services/evaluation-rule.engine.ts
@@ -17,11 +17,12 @@ export interface EvalResult {
 }
 
 const ajv = new Ajv();
-const compiledSchemaCache = new Map<Record<string, unknown>, ReturnType<typeof ajv.compile>>();
+const compiledSchemaCache = new Map<string, ReturnType<typeof ajv.compile>>();
 const MAX_CACHE_SIZE = 100;
 
 function getCachedValidator(schema: Record<string, unknown>) {
-  const cached = compiledSchemaCache.get(schema);
+  const key = JSON.stringify(schema);
+  const cached = compiledSchemaCache.get(key);
   if (cached) return cached;
 
   const validator = ajv.compile(schema);
@@ -33,7 +34,7 @@ function getCachedValidator(schema: Record<string, unknown>) {
     }
   }
 
-  compiledSchemaCache.set(schema, validator);
+  compiledSchemaCache.set(key, validator);
   return validator;
 }
 

--- a/tests/unit/services/cache.service.test.ts
+++ b/tests/unit/services/cache.service.test.ts
@@ -7,6 +7,7 @@ const mockRedisClient = {
   del: jest.fn(),
   flushall: jest.fn(),
   keys: jest.fn(),
+  scan: jest.fn(),
 };
 
 jest.mock('@services/redis.service', () => ({
@@ -121,12 +122,12 @@ describe('CacheService', () => {
   });
 
   it('should invalidate via Redis when enabled', async () => {
-    mockRedisClient.keys.mockResolvedValue(['prompt:default:multi:1.0.0']);
+    mockRedisClient.scan.mockResolvedValue(['0', ['prompt:default:multi:1.0.0']]);
     (redisService.isRedisEnabled as jest.Mock).mockReturnValue(true);
     (redisService.getRedisClient as jest.Mock).mockReturnValue(mockRedisClient);
 
     await invalidatePrompt(WORKSPACE, 'multi');
-    expect(mockRedisClient.keys).toHaveBeenCalledWith('prompt:default:multi:*');
+    expect(mockRedisClient.scan).toHaveBeenCalledWith('0', 'MATCH', 'prompt:default:multi:*', 'COUNT', 100);
     expect(mockRedisClient.del).toHaveBeenCalledWith('prompt:default:multi:1.0.0');
   });
 });


### PR DESCRIPTION
## Fixes

- **#127**: Fix evaluation-rule schema cache — use `JSON.stringify(schema)` as the cache key instead of object reference identity. The previous `Map<Record<string, unknown>, ...>` never hit because callers pass new object literals each time, causing memory leaks of up to 100 redundant compiled Ajv schemas.
- **#128**: Replace `redis.keys()` with `redis.scan()` (cursor-based iteration) in `invalidatePrompt` and `clearCache`. `KEYS` is O(N) and blocks the Redis event loop; `SCAN` is non-blocking.
- **#134**: Remove the impossible `RETURNING id` retry inside `TransactionPreparedStatement.run()`. Inside a PostgreSQL transaction, a 42703 error aborts the transaction, making retry impossible. The code now only attempts `RETURNING id` for tables known to have an `id` column (via `TABLES_WITHOUT_ID` check).

## Test Results
All 383 unit tests pass, including the updated cache service test.