### PR TITLE
fix: v1.5.1 bugfixes — duplicate prompt, rate limit, error format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-05-18
+
+### Fixed
+
+- **Filesystem driver duplicate prompt** — `FilesystemDriver.createPrompt` silently overwrote existing prompt files instead of returning an error. Now checks `fs.existsSync` before writing and throws if the file already exists, matching the DB driver's duplicate detection behavior.
+- **SQLite rate limit contention** — `checkSqliteRateLimit` used a non-atomic three-step sequence (UPDATE, INSERT, retry UPDATE) that caused premature 429s and over-counting under concurrent requests. Rewritten to use `db.transaction()` for atomic check-and-increment, eliminating the race condition. The transaction also reads the count within the same transaction, fixing stale `RateLimit-Remaining` headers.
+- **Error response format inconsistency** — `AppError.details` was typed as `unknown`, producing three distinct shapes across the API (`string[]`, `{ [key: string]: unknown }`, or absent). Normalized to `Record<string, unknown>` (aliased as `ErrorDetails`). `validationFailed()` now normalizes `string[]` (from Joi) to `{ fields: string[] }`. Query validation errors now return `422 VALIDATION_FAILED` (was `400 BAD_REQUEST`) for consistency with body validation.
+
 ## [1.5.0] - 2026-05-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Migrations are numbered TypeScript files in `migrations/`. They use dialect-awar
 2. `PromptController` handles HTTP concerns (pagination, query parsing) then delegates to `PromptService`.
 3. `getPrompt` performs Mustache variable substitution on `system` and `user` role messages. Cached in LRU (or Redis when `REDIS_URL` is set).
 4. Read operations filter on `status = 'active'`, so incomplete writes are invisible.
-5. Validation is done via Joi schemas in `src/validation-schemas/` and returns 422 with a `details` array.
+5. Validation is done via Joi schemas in `src/validation-schemas/` and returns 422 with a `details` object. Joi validation errors are normalized to `{ fields: string[] }`. Business errors use `{ key: value }` shapes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Self-hosted with no vendor lock-in. Prompt content lives in Git, not a database.
 
 ---
 
-## What's New in v1.5.0
+## What's New in v1.5.1
+
+- **Filesystem Duplicate Prompt Fix** — Creating a prompt that already exists on disk now returns an error instead of silently overwriting the file.
+- **SQLite Rate Limit Fix** — Fixed race condition that caused premature 429s and stale `RateLimit-Remaining` headers under concurrent requests. Rate limit checks are now atomic via `db.transaction()`.
+- **Error Response Normalization** — All validation errors now return `422 VALIDATION_FAILED` with a consistent `details` shape (`{ fields: string[] }` for Joi errors, `{ key: value }` for business errors). Query validation errors previously returned `400 BAD_REQUEST` with bare `string[]` details.
+
+### Previous: v1.5.0
 
 - **Trace & Run Deletion** — `DELETE /v1/traces/:trace_id` and `DELETE /v1/runs/:run_id` endpoints for cleaning up data. Trace deletion cascades to spans. Both require `write` scope and produce audit log entries.
 - **Expanded Span Status** — Span `status` now accepts `unset`, `ok`, `error`, and `running` (matching OpenTelemetry conventions). `status` is optional and defaults to `unset`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptmetrics",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Lightweight, self-hosted prompt registry with versioning, metadata logging, evaluations, and multi-tenant observability",
   "main": "dist/server.js",
   "bin": {

--- a/src/drivers/promptmetrics-filesystem-driver.ts
+++ b/src/drivers/promptmetrics-filesystem-driver.ts
@@ -85,6 +85,9 @@ export class FilesystemDriver implements PromptDriver {
     }
 
     const filePath = path.join(promptDir, `${prompt.version}.json`);
+    if (fs.existsSync(filePath)) {
+      throw new Error(`Prompt already exists: ${prompt.name} v${prompt.version}`);
+    }
     fs.writeFileSync(filePath, JSON.stringify(prompt, null, 2), 'utf-8');
 
     const stats = fs.statSync(filePath);

--- a/src/errors/app.error.ts
+++ b/src/errors/app.error.ts
@@ -1,9 +1,11 @@
+export type ErrorDetails = Record<string, unknown>;
+
 export class AppError extends Error {
   public readonly statusCode: number;
   public readonly code: string;
-  public readonly details?: unknown;
+  public readonly details?: ErrorDetails;
 
-  constructor(message: string, statusCode: number, code: string, details?: unknown) {
+  constructor(message: string, statusCode: number, code: string, details?: ErrorDetails) {
     super(message);
     this.statusCode = statusCode;
     this.code = code;
@@ -11,7 +13,7 @@ export class AppError extends Error {
     Error.captureStackTrace(this, this.constructor);
   }
 
-  static badRequest(message: string, details?: unknown): AppError {
+  static badRequest(message: string, details?: ErrorDetails): AppError {
     return new AppError(message, 400, 'BAD_REQUEST', details);
   }
 
@@ -27,8 +29,13 @@ export class AppError extends Error {
     return new AppError(`${resource} not found`, 404, 'NOT_FOUND');
   }
 
-  static validationFailed(details: unknown): AppError {
-    return new AppError('Validation failed', 422, 'VALIDATION_FAILED', details);
+  /** Validation error with structured details.
+   *  Accepts either a string[] (from Joi) or an ErrorDetails object.
+   *  String arrays are normalized to { fields: string[] }.
+   */
+  static validationFailed(details: string[] | ErrorDetails): AppError {
+    const normalized: ErrorDetails = Array.isArray(details) ? { fields: details } : details;
+    return new AppError('Validation failed', 422, 'VALIDATION_FAILED', normalized);
   }
 
   static internal(message?: string): AppError {

--- a/src/middlewares/promptmetrics-query-validation.middleware.ts
+++ b/src/middlewares/promptmetrics-query-validation.middleware.ts
@@ -6,10 +6,7 @@ export function validateQuery(schema: Joi.ObjectSchema) {
   return (req: Request, _res: Response, next: NextFunction): void => {
     const { error, value } = schema.validate(req.query, { abortEarly: false });
     if (error) {
-      throw AppError.badRequest(
-        'Invalid query parameters',
-        error.details.map((d) => d.message),
-      );
+      throw AppError.validationFailed(error.details.map((d) => d.message));
     }
     req.validatedQuery = value;
     next();

--- a/src/middlewares/rate-limit-per-key.middleware.ts
+++ b/src/middlewares/rate-limit-per-key.middleware.ts
@@ -77,35 +77,49 @@ async function checkSqliteRateLimit(
     const now = Date.now();
     const windowStart = Math.floor(now / windowMs) * windowMs;
 
-    const updateResult = await db
-      .prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ? AND window_start = ? AND count < ?')
-      .run(rateLimitKey, windowStart, maxRequests);
+    // Use a transaction to make the check-and-increment atomic,
+    // preventing race conditions under concurrent requests.
+    // Returns { allowed: boolean, count: number } so we can distinguish
+    // between "we just incremented to max" (allowed) and "already at max" (blocked).
+    const result = await db.transaction(async (): Promise<{ allowed: boolean; count: number }> => {
+      // Try to increment an existing row for the current window.
+      // Only increments when count < maxRequests, so a successful increment
+      // means this request is within the limit.
+      const updateResult = await db
+        .prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ? AND window_start = ? AND count < ?')
+        .run(rateLimitKey, windowStart, maxRequests);
 
-    let incremented = updateResult.changes > 0;
-
-    if (!incremented) {
-      const insertResult = await db
-        .prepare(
-          `INSERT INTO rate_limits (key, window_start, count)
-         VALUES (?, ?, 1)
-         ON CONFLICT(key) DO UPDATE SET
-           window_start = excluded.window_start,
-           count = excluded.count
-         WHERE rate_limits.window_start < excluded.window_start`,
-        )
-        .run(rateLimitKey, windowStart);
-      incremented = insertResult.changes > 0;
-
-      if (!incremented) {
-        // Another request may have initialized the row; retry the atomic update once.
-        const retryResult = await db
-          .prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ? AND window_start = ? AND count < ?')
-          .run(rateLimitKey, windowStart, maxRequests);
-        incremented = retryResult.changes > 0;
+      if (updateResult.changes > 0) {
+        // We incremented successfully — this request is within the limit.
+        const row = (await db.prepare('SELECT count FROM rate_limits WHERE key = ?').get(rateLimitKey)) as
+          | { count: number }
+          | undefined;
+        return { allowed: true, count: row?.count ?? 1 };
       }
-    }
 
-    if (!incremented) {
+      // No row was updated. Either no row exists for this key/window,
+      // or the count has reached maxRequests.
+      const row = (await db.prepare('SELECT window_start, count FROM rate_limits WHERE key = ?').get(rateLimitKey)) as
+        | { window_start: number; count: number }
+        | undefined;
+
+      if (!row || row.window_start < windowStart) {
+        // New window or first request — insert/reset the counter to 1.
+        await db
+          .prepare(
+            `INSERT INTO rate_limits (key, window_start, count) VALUES (?, ?, 1)
+             ON CONFLICT(key) DO UPDATE SET window_start = excluded.window_start, count = excluded.count`,
+          )
+          .run(rateLimitKey, windowStart);
+        return { allowed: true, count: 1 };
+      }
+
+      // Row exists for the current window and count >= maxRequests.
+      // This request is over the limit.
+      return { allowed: false, count: row.count };
+    });
+
+    if (!result.allowed) {
       const retryAfter = Math.ceil((windowStart + windowMs - now) / 1000);
       res.setHeader('Retry-After', String(retryAfter));
       res.status(429).json({
@@ -115,13 +129,9 @@ async function checkSqliteRateLimit(
       return true;
     }
 
-    const row = (await db.prepare('SELECT count FROM rate_limits WHERE key = ?').get(rateLimitKey)) as
-      | { count: number }
-      | undefined;
-
-    const count = row?.count ?? 1;
+    const remaining = Math.max(0, maxRequests - result.count);
     res.setHeader('RateLimit-Limit', String(maxRequests));
-    res.setHeader('RateLimit-Remaining', String(Math.max(0, maxRequests - count)));
+    res.setHeader('RateLimit-Remaining', String(remaining));
     res.setHeader('RateLimit-Reset', String(Math.ceil((windowStart + windowMs) / 1000)));
     return false;
   } catch (err) {

--- a/src/services/audit-log.service.ts
+++ b/src/services/audit-log.service.ts
@@ -64,17 +64,19 @@ class AuditLogService {
 
     for (const entry of batch) {
       try {
-        await db.prepare(
-          'INSERT INTO audit_logs (action, prompt_name, version_tag, target_id, api_key_name, ip_address, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
-        ).run(
-          entry.action,
-          entry.prompt_name || null,
-          entry.version_tag || null,
-          entry.target_id || null,
-          entry.api_key_name,
-          entry.ip_address,
-          entry.workspace_id || 'default',
-        );
+        await db
+          .prepare(
+            'INSERT INTO audit_logs (action, prompt_name, version_tag, target_id, api_key_name, ip_address, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          )
+          .run(
+            entry.action,
+            entry.prompt_name || null,
+            entry.version_tag || null,
+            entry.target_id || null,
+            entry.api_key_name,
+            entry.ip_address,
+            entry.workspace_id || 'default',
+          );
       } catch (err) {
         console.error('Failed to write audit log entry:', err);
         this.buffer.unshift(entry);

--- a/tests/unit/middlewares/rate-limit-per-key.middleware.test.ts
+++ b/tests/unit/middlewares/rate-limit-per-key.middleware.test.ts
@@ -56,7 +56,10 @@ describe('rateLimitPerKey middleware', () => {
     const pipelineMock: any = {
       incr: jest.fn().mockImplementation(() => pipelineMock),
       expire: jest.fn().mockImplementation(() => pipelineMock),
-      exec: jest.fn().mockResolvedValue([[null, 5], [null, 1]]),
+      exec: jest.fn().mockResolvedValue([
+        [null, 5],
+        [null, 1],
+      ]),
     };
     const redisMock = {
       pipeline: jest.fn().mockReturnValue(pipelineMock),
@@ -78,7 +81,10 @@ describe('rateLimitPerKey middleware', () => {
     const pipelineMock: any = {
       incr: jest.fn().mockImplementation(() => pipelineMock),
       expire: jest.fn().mockImplementation(() => pipelineMock),
-      exec: jest.fn().mockResolvedValue([[null, 11], [null, 1]]),
+      exec: jest.fn().mockResolvedValue([
+        [null, 11],
+        [null, 1],
+      ]),
     };
     const redisMock = {
       pipeline: jest.fn().mockReturnValue(pipelineMock),
@@ -109,21 +115,27 @@ describe('rateLimitPerKey middleware', () => {
     expect(mockGetDb).not.toHaveBeenCalled();
   });
 
-  it('falls through to SQLite when Redis client is not available', async () => {
+  it('allows request and sets headers via SQLite transaction', async () => {
     mockGetRedisClient.mockReturnValue(null);
-    const runMock = jest.fn().mockResolvedValue({ changes: 1 });
-    const getMock = jest.fn().mockResolvedValue({ count: 1 });
-    mockGetDb.mockReturnValue({
-      prepare: jest.fn().mockImplementation((sql: string) => {
-        if (sql.includes('UPDATE rate_limits')) {
-          return { run: runMock };
-        }
-        if (sql.includes('SELECT count FROM rate_limits')) {
-          return { get: getMock };
-        }
-        return { run: runMock, get: getMock };
-      }),
+
+    const mockPrepare = jest.fn().mockImplementation((sql: string) => {
+      if (sql.includes('UPDATE rate_limits')) {
+        return { run: jest.fn().mockResolvedValue({ changes: 1 }) };
+      }
+      if (sql.includes('SELECT count')) {
+        return { get: jest.fn().mockResolvedValue({ count: 1 }) };
+      }
+      return { run: jest.fn().mockResolvedValue({ changes: 1 }), get: jest.fn().mockResolvedValue({ count: 1 }) };
     });
+
+    const mockDb = {
+      prepare: mockPrepare,
+      transaction: jest.fn(async (fn: any) => {
+        return fn({ prepare: mockPrepare });
+      }),
+    };
+
+    mockGetDb.mockReturnValue(mockDb);
 
     req = { headers: { 'x-api-key': 'key1' }, workspaceId: 'ws1' };
     const middleware = rateLimitPerKey(60_000, 10);
@@ -131,5 +143,6 @@ describe('rateLimitPerKey middleware', () => {
 
     expect(next).toHaveBeenCalled();
     expect(setHeaderMock).toHaveBeenCalledWith('RateLimit-Limit', '10');
+    expect(setHeaderMock).toHaveBeenCalledWith('RateLimit-Remaining', '9');
   });
 });


### PR DESCRIPTION
## Summary

- **Filesystem duplicate prompt** — `FilesystemDriver.createPrompt` silently overwrote existing prompt files. Now checks `fs.existsSync` before writing and throws if the file exists, matching DB driver behavior.
- **SQLite rate limit contention** — `checkSqliteRateLimit` used a non-atomic 3-step sequence causing premature 429s and over-counting under concurrent requests. Rewritten with `db.transaction()` for atomic check-and-increment; also fixed stale `RateLimit-Remaining` headers.
- **Error response format inconsistency** — `AppError.details` was typed as `unknown`, producing 3 distinct shapes (`string[]`, `{ key: value }`, or absent). Normalized to `ErrorDetails` (`Record<string, unknown>`). `validationFailed()` normalizes `string[]` to `{ fields: string[] }`. Query validation now returns `422 VALIDATION_FAILED` (was `400 BAD_REQUEST`).

## Test plan

- [x] All 592 existing tests pass
- [x] Rate limit unit tests updated for new `db.transaction()` mock
- [x] Rate limit integration tests pass (concurrent request test, header tests, independent key counters)
- [x] `npm run lint` — 0 errors, 11 pre-existing warnings

## Files changed

| File | Change |
|------|--------|
| `src/drivers/promptmetrics-filesystem-driver.ts` | Added `fs.existsSync` duplicate check |
| `src/middlewares/rate-limit-per-key.middleware.ts` | Rewrote `checkSqliteRateLimit` with transaction |
| `src/errors/app.error.ts` | Added `ErrorDetails` type, normalized `validationFailed` |
| `src/middlewares/promptmetrics-query-validation.middleware.ts` | Changed to 422 `VALIDATION_FAILED` |
| `tests/unit/middlewares/rate-limit-per-key.middleware.test.ts` | Updated mock for transaction |
| `package.json` | Version bump to 1.5.1 |
| `CHANGELOG.md` | Added v1.5.1 entry |
| `README.md` | Added v1.5.1 section |
| `CLAUDE.md` | Updated validation docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)